### PR TITLE
Feature/sampling rate

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,3 +2,7 @@ INFLUX_URL=http://localhost:8086
 INFLUX_TOKEN=my_token
 INFLUX_ORG=my_org
 INFLUX_BUCKET=my_bucket
+
+# RuuviTags are updated every 10 seconds. This frequency is way more than required for most use
+# cases, so we use a lower sampling rate to reduce the amount of data saved to InfluxDB.
+SAMPLING_RATE=0.025

--- a/src/config.js
+++ b/src/config.js
@@ -17,7 +17,15 @@ const influx = {
     bucket: process.env.INFLUX_BUCKET,
 }
 
+/**
+ * RuuviTags are updated every 10 seconds. This frequency is way more than required for most use
+ * cases, so we use a lower sampling rate to reduce the amount of data saved to InfluxDB.
+ * @type {number}
+ */
+const samplingRate = process.env.SAMPLING_RATE || 0.05;
+
 module.exports = {
     aliases,
     influx,
+    samplingRate,
 };

--- a/src/index.js
+++ b/src/index.js
@@ -13,6 +13,7 @@ const writer = new InfluxWriter(config.influx);
  */
 ruuvi.on('found', (tag) => {
     const options = {};
+    let sample = -1;
 
     // set tag alias in options if defined in config
     if (config.aliases[tag.address]) {
@@ -20,7 +21,9 @@ ruuvi.on('found', (tag) => {
     }
 
     tag.on('updated', (data) => {
-        writer.write(tag, data, options);
+        if ((++sample * config.samplingRate) % 1 === 0) {
+            writer.write(tag, data, options);
+        }
     });
 });
 


### PR DESCRIPTION
Add a configurable sampling rate variable to control how often an update from Ruuvi Tag is written to InfluxDB. This is useful to reduce space used by InfluxDB bucket when a lower frequency of data points is accurate enough.